### PR TITLE
Resolve issue #34: Face ID support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ First you'll want to check whether or not the user has a configured fingerprint 
 You can use this to show a 'log in with your fingerprint' button next to a username/password login form.
 ```js
 window.plugins.touchid.isAvailable(
+  false,
   function() {alert('available!')}, // success handler: TouchID available
   function(msg) {alert('not available, message: ' + msg)} // error handler: no TouchID available
 );
@@ -108,7 +109,7 @@ window.plugins.touchid.verifyFingerprintWithCustomPasswordFallbackAndEnterPasswo
 
 You can copy-paste these lines of code for a quick test:
 ```html
-<button onclick="window.plugins.touchid.isAvailable(function(msg) {alert('ok: ' + msg)}, function(msg) {alert('not ok: ' + msg)})">Touch ID available?</button>
+<button onclick="window.plugins.touchid.isAvailable(false, function(msg) {alert('ok: ' + msg)}, function(msg) {alert('not ok: ' + msg)})">Touch ID available?</button>
 <button onclick="window.plugins.touchid.verifyFingerprint('Scan your fingerprint please', function(msg) {alert('ok: ' + msg)}, function(msg) {alert('not ok: ' + JSON.stringify(msg))})">Scan fingerprint</button>
 ```
 
@@ -123,6 +124,7 @@ before accepting valid fingerprints again.
 
 ```js
 window.plugins.touchid.isAvailable(
+    false,
     // success handler; available
     function() {
       window.plugins.touchid.didFingerprintDatabaseChange(
@@ -139,5 +141,34 @@ window.plugins.touchid.isAvailable(
     function(msg) {
       // use a more traditional auth mechanism
     }
+);
+```
+
+## Face ID Support
+Since iOS 11, LocalAuthentication also supports Face ID for biometrics. This is
+a drop-in replacement for Touch ID and any existing apps using Touch ID will
+work identically on devices that use Face ID.
+
+In order to determine the biometry type, an optional argument has been added to
+the `isAvailable` method which will return the type as a string as `'face'` or
+`'touch'` when available. You can use this to display "Face ID" or "Touch ID"
+as appropriate in your app.
+
+```js
+window.plugins.touchid.isAvailable(
+  true,
+  function(type) {alert(type)}, // type returned to success callback: 'face' on iPhone X, 'touch' on other devices
+  function(msg) {alert('not available, message: ' + msg)} // error handler: no TouchID available
+);
+
+window.plugins.touchid.isAvailable(
+  false,
+  function() {alert('available')}, // Nothing returned to success callback
+  function(msg) {alert('not available, message: ' + msg)} // error handler: no TouchID available
+);
+
+window.plugins.touchid.isAvailable(
+  function() {alert('available')}, // Nothing returned to success callback
+  function(msg) {alert('not available, message: ' + msg)} // error handler: no TouchID available
 );
 ```

--- a/src/ios/TouchID.m
+++ b/src/ios/TouchID.m
@@ -22,8 +22,23 @@ NSString *keychainItemServiceName;
     LAContext *laContext = [[LAContext alloc] init];
 
     if ([laContext canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&error]) {
-      [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK]
-                                  callbackId:command.callbackId];
+      NSString *biometryType = @"";
+      if (@available(iOS 11.0, *)) {
+        if ([command.arguments objectAtIndex:0]) {
+          if (laContext.biometryType == LABiometryTypeFaceID) {
+            biometryType = @"face";
+          }
+          else {
+            biometryType = @"touch";
+          }
+          [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:biometryType]
+                                      callbackId:command.callbackId];
+        }
+      }
+      else {
+        [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK]
+                                    callbackId:command.callbackId];
+      }
     } else {
       NSArray *errorKeys = @[@"code", @"localizedDescription"];
       [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:[error dictionaryWithValuesForKeys:errorKeys]]

--- a/www/TouchID.js
+++ b/www/TouchID.js
@@ -1,8 +1,8 @@
 function TouchID() {
 }
 
-TouchID.prototype.isAvailable = function (successCallback, errorCallback) {
-  cordova.exec(successCallback, errorCallback, "TouchID", "isAvailable", []);
+TouchID.prototype.isAvailable = function (checkBiometricType, successCallback, errorCallback) {
+  cordova.exec(successCallback, errorCallback, "TouchID", "isAvailable", [!!checkBiometricType]);
 };
 
 TouchID.prototype.didFingerprintDatabaseChange = function (successCallback, errorCallback) {

--- a/www/TouchID.js
+++ b/www/TouchID.js
@@ -2,6 +2,13 @@ function TouchID() {
 }
 
 TouchID.prototype.isAvailable = function (checkBiometricType, successCallback, errorCallback) {
+  // Make two-argument method for backwards compatibility. If first argument
+  // is not a boolean, assume first two arguments are callback functions.
+  if (typeof checkBiometricType !== 'boolean') {
+    errorCallback = successCallback;
+    successCallback = checkBiometricType;
+    checkBiometricType = false;
+  }
   cordova.exec(successCallback, errorCallback, "TouchID", "isAvailable", [!!checkBiometricType]);
 };
 


### PR DESCRIPTION
Face ID is supported out of the box, but I updated the API to allow developers to determine the biometric type used for auth (currently face or touch).

This was done by adding a property to the isAvailable method allowing it to return a string with 'face' or 'touch' type. Adding this new property was done for backward compatibility of the existing API. I thought this was the best spot for it since `canEvaulatePolicy` has to be called anyway in order to set `biometryType`.

This allows developers to update places in their app where `'Touch ID'` should be replaced with `'Face ID'`. Otherwise, nothing is needed and Face ID will just work in the same way that Touch ID has before.

Fixes: #34 